### PR TITLE
Add support for stability analysis

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,6 @@ jobs:
       # multiple arguments to it through MSBuild.
       run: |
         for iter in 1 2 3 4 5; do
-          (cd src && dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$iter src/Main.dfy)
+          (cd src && dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$iter Main.dfy)
         done
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 100 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Self Report
       # Generates a report based on the logged data from verifying itself.
       # This is both a guard against unstable verification and a smoke test of the tool itself.
-      run: dotnet run --project src -- summarize-csv-results --max-resource-count 1000000 .
+      run: dotnet run --project src -- summarize-csv-results --max-resource-count 1500000 .
     - name: Stability Analysis
       # Analyzes the stability of verification by running it several
       # more times and calculating statistics

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,4 +41,4 @@ jobs:
         for iter in 1 2 3 4 5; do
           (cd src && dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$iter Main.dfy)
         done
-        dotnet run --project src -- summarize-csv-results --max-resource-stddev 100 .
+        dotnet run --project src -- summarize-csv-results --max-resource-stddev 100000 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,6 +36,7 @@ jobs:
       # more times and calculating statistics
       run: |
         for iter in 1 2 3 4 5; do
-          dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv"
+          dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2
+          -p:TestVerifyOverride="verificationLogger:csv" -p:TestVerifyOverride="randomSeed:$iter"
         done
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 100 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,7 @@ jobs:
       # Runs Dafny directly because it doesn't seem like we can pass
       # multiple arguments to it through MSBuild.
       run: |
-        for iter in 1 2 3 4 5; do
-          (cd src && dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$iter Main.dfy)
+        for seed in 1 2 3 4 5; do
+          (cd src && dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$seed Main.dfy)
         done
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 100000 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,3 +31,11 @@ jobs:
       # Generates a report based on the logged data from verifying itself.
       # This is both a guard against unstable verification and a smoke test of the tool itself.
       run: dotnet run --project src -- summarize-csv-results --max-resource-count 1000000 .
+    - name: Stability Analysis
+      # Analyzes the stability of verification by running it several
+      # more times and calculating statistics
+      run: |
+        for iter in 1 2 3 4 5; do
+          dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv"
+        done
+        dotnet run --project src -- summarize-csv-results --max-resource-stddev 100 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,6 @@ jobs:
       # more times and calculating statistics
       run: |
         for iter in 1 2 3 4 5; do
-          dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2
-          -p:TestVerifyOverride="verificationLogger:csv" -p:TestVerifyOverride="randomSeed:$iter"
+          dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" -p:TestVerifyOverride="randomSeed:$iter"
         done
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 100 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,8 +34,11 @@ jobs:
     - name: Stability Analysis
       # Analyzes the stability of verification by running it several
       # more times and calculating statistics
+      #
+      # Runs Dafny directly because it doesn't seem like we can pass
+      # multiple arguments to it through MSBuild.
       run: |
         for iter in 1 2 3 4 5; do
-          dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv" -p:TestVerifyOverride="randomSeed:$iter"
+          (cd src && dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$iter src/Main.dfy)
         done
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 100 .

--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -63,6 +63,53 @@ namespace Externs_Compile {
       return charseq.FromString(n.ToString());
     }
 
+    private static bool TryBigRationalToDouble(BigRational r, out Double d) {
+      // This is kind of ridiculous. We could certainly improve the BigRational
+      // class to make stuff like this easier. Conversion to and from `double`
+      // would probably be worth including.
+      string rStr = r.ToString();
+      double num, den;
+      if(Double.TryParse(rStr, out var result)) {
+        d = result;
+        return true;
+      }
+      var parts = r.ToString().Trim(new char[] {'(', ')'}).Split('/', StringSplitOptions.TrimEntries);
+      if(parts.Length != 2) {
+        d = 0.0;
+        return false;
+      }
+      if(!Double.TryParse(parts[0], out num)) {
+        d = 0.0;
+        return false;
+      }
+      if(!Double.TryParse(parts[1], out den)) {
+        d = 0.0;
+        return false;
+      }
+      d = num / den;
+      return true;
+    }
+
+    public static icharseq RealToString(BigRational r) {
+      if(TryBigRationalToDouble(r, out var d)) {
+        return charseq.FromString(d.ToString());
+      } else {
+        return charseq.FromString("Failed to convert real to string");
+      }
+    }
+
+    public static BigRational Sqrt(BigRational r) {
+      if(TryBigRationalToDouble(r, out var d)) {
+        var sqrt = Math.Sqrt(d);
+        double multiplier = 1000000000.0;
+        return new BigRational(
+                 new BigInteger(sqrt * multiplier),
+                 new BigInteger((long)multiplier));
+      } else {
+        return new BigRational(-1, 1);
+      }
+    }
+
     public static _IResult<long, icharseq> ParseDurationTicks(icharseq dafnyString) {
       var s = dafnyString.ToString();
       try {

--- a/src/Externs.dfy
+++ b/src/Externs.dfy
@@ -17,6 +17,9 @@ module Externs {
   function method {:extern} NatToString(n: nat): string
   function method {:extern} ParseDurationTicks(s: string): Result<int64, string>
   function method {:extern} DurationTicksToString(n: int64): string
+  function method {:extern} RealToString(n: real): string
+
+  function method {:extern} Sqrt(n: real): real
 
   const DurationTicksPerSecond := 10_000_000;
 }

--- a/src/Main.dfy
+++ b/src/Main.dfy
@@ -110,33 +110,31 @@ module Main {
 
     if options.maxDurationStddev.Some? {
       var stddevs := ResultGroupDurationStddevs(groupedResults);
-      var exceedingStddevs := Filter((t:(string, real)) => options.maxDurationStddev.value as real < t.1, stddevs);
-      if 0 < |exceedingStddevs| {
-        passed := false;
-        print "\nSome results have a duration standard deviation over the configured limit of ", options.maxDurationStddev.value, ":\n\n";
-        for resIdx := 0 to |exceedingStddevs| {
-          var t : (string, real) := exceedingStddevs[resIdx];
-          print t.0, ": stddev = ", Externs.RealToString(t.1), "\n";
-        }
-      }
+      passed := PrintExceedingStddevs("duration", stddevs, options.maxDurationStddev.value as real);
     }
 
     if options.maxResourceStddev.Some? {
       var stddevs := ResultGroupResourceStddevs(groupedResults);
-      var exceedingStddevs := Filter((t:(string, real)) => options.maxResourceStddev.value as real < t.1, stddevs);
-      if 0 < |exceedingStddevs| {
-        passed := false;
-        print "\nSome results have a resource count standard deviation over the configured limit of ", options.maxResourceStddev.value, ":\n\n";
-        for resIdx := 0 to |exceedingStddevs| {
-          var t : (string, real) := exceedingStddevs[resIdx];
-          print t.0, ": stddev = ", Externs.RealToString(t.1), "\n";
-        }
-      }
+      passed := PrintExceedingStddevs("resource count", stddevs, options.maxResourceStddev.value as real);
     }
 
     :- Need(passed, "\nErrors occurred: see above for details.\n");
 
     return Success(());
+  }
+
+  method PrintExceedingStddevs(description: string, stddevs: seq<(string, real)>, limit: real) returns (passed: bool) {
+      var exceedingStddevs := Filter((t:(string, real)) => limit < t.1, stddevs);
+      if 0 < |exceedingStddevs| {
+        passed := false;
+        print "\nSome results have a ", description, " standard deviation over the configured limit of ", limit, ":\n\n";
+        for resIdx := 0 to |exceedingStddevs| {
+          var t : (string, real) := exceedingStddevs[resIdx];
+          print t.0, ": stddev = ", Externs.RealToString(t.1), "\n";
+        }
+      } else {
+        passed := true;
+      }
   }
 
   method PrintTestResults(results: seq<TestResult.TestResult>) {

--- a/src/Main.dfy
+++ b/src/Main.dfy
@@ -34,6 +34,8 @@ module Main {
   datatype Options = Options(justHelpText: bool := false,
                              maxDurationSeconds: Option<nat> := None, 
                              maxResourceCount: Option<nat> := None,
+                             maxDurationStddev: Option<nat> := None,
+                             maxResourceStddev: Option<nat> := None,
                              filePaths: seq<string> := [])
 
   // TODO: It would be nice to return an `Outcome<string>` instead, but the current
@@ -63,9 +65,17 @@ module Main {
     // Sort by the negative resource count in order to sort from highest to lowest
     var negativeResourceCountGetter: TestResult.TestResult -> int := (r: TestResult.TestResult) => -(r.resourceCount as int);
     var allResultsSorted := StandardLibrary.MergeSortBy(allResults, negativeResourceCountGetter);
+
+    // Group the results by name, for aggregate statistics
+    var groupedResults := GroupTestResults(allResultsSorted);
     
-    print "All results: \n\n";
-    PrintTestResults(allResultsSorted);
+    if options.maxResourceStddev.Some? || options.maxDurationStddev.Some? {
+      print "All results (statistics):\n\n";
+      PrintAllTestResultStatistics(groupedResults);
+    } else {
+      print "All results: \n\n";
+      PrintTestResults(allResultsSorted);
+    }
 
     var passed := true;
 
@@ -98,6 +108,32 @@ module Main {
       }
     }
 
+    if options.maxDurationStddev.Some? {
+      var stddevs := ResultGroupDurationStddevs(groupedResults);
+      var exceedingStddevs := Filter((t:(string, real)) => options.maxDurationStddev.value as real < t.1, stddevs);
+      if 0 < |exceedingStddevs| {
+        passed := false;
+        print "\nSome results have a duration standard deviation over the configured limit of ", options.maxDurationStddev.value, ":\n\n";
+        for resIdx := 0 to |exceedingStddevs| {
+          var t : (string, real) := exceedingStddevs[resIdx];
+          print t.0, ": stddev = ", Externs.RealToString(t.1), "\n";
+        }
+      }
+    }
+
+    if options.maxResourceStddev.Some? {
+      var stddevs := ResultGroupResourceStddevs(groupedResults);
+      var exceedingStddevs := Filter((t:(string, real)) => options.maxResourceStddev.value as real < t.1, stddevs);
+      if 0 < |exceedingStddevs| {
+        passed := false;
+        print "\nSome results have a resource count standard deviation over the configured limit of ", options.maxResourceStddev.value, ":\n\n";
+        for resIdx := 0 to |exceedingStddevs| {
+          var t : (string, real) := exceedingStddevs[resIdx];
+          print t.0, ": stddev = ", Externs.RealToString(t.1), "\n";
+        }
+      }
+    }
+
     :- Need(passed, "\nErrors occurred: see above for details.\n");
 
     return Success(());
@@ -110,13 +146,21 @@ module Main {
   }
 
   const helpText :=
-      "usage: dafny-reportgenerator summarize-csv-results [--max-resource-count N] [--max-duration-seconds N] [file_paths ...]\n" +
+      "usage: dafny-reportgenerator summarize-csv-results [--max-resource-count N]\n" +
+      "                                                   [--max-duration-seconds N]\n" +
+      "                                                   [--max-resource-stddev N]\n" +
+      "                                                   [--max-duration-stddev N]\n" +
+      "                                                   [file_paths ...]\n" +
       "\n" +
       "file_paths                 CSV files produced from Dafny's /verificationLogger:csv feature.\n" +
       "                           Directory paths are also accepted, in which case all CSV files under all\n" +
       "                           \"TestResults\" descendant directories are included.\n" +
       "--max-resource-count N     Fail if any results have a resource count over the given value.\n" +
       "--max-duration-seconds N   Fail if any results have a duration over the given value in seconds.\n" +
+      "--max-resource-stddev N    Fail if multiple results exist for each proof obligation and the standard\n" +
+      "                           deviation of their resource counts is over the given value.\n" +
+      "--max-duration-stddev N    Fail if multiple results exist for each proof obligation and the standard\n" +
+      "                           deviation of their durations is over the given value.\n" +
       "";
 
   method ParseCommandLineOptions(args: seq<string>) returns (result: Result<Options, string>) {
@@ -132,6 +176,8 @@ module Main {
 
     var maxResourceCount: Option<nat> := None;
     var maxDurationSeconds: Option<nat> := None;
+    var maxResourceStddev: Option<nat> := None;
+    var maxDurationStddev: Option<nat> := None;
     var filePaths: seq<string> := [];
     var argIndex := 2;
     while argIndex < |args| {
@@ -149,6 +195,18 @@ module Main {
           var count :- Externs.ParseNat(args[argIndex]);
           maxDurationSeconds := Some(count);
         }
+        case "--max-resource-stddev" => {
+          :- Need(argIndex + 1 < |args|, "--max-resource-stddev must be followed by an argument\n\n" + helpText);
+          argIndex := argIndex + 1;
+          var count :- Externs.ParseNat(args[argIndex]);
+          maxResourceStddev := Some(count);
+        }
+        case "--max-duration-stddev" => {
+          :- Need(argIndex + 1 < |args|, "--max-duration-stddev must be followed by an argument\n\n" + helpText);
+          argIndex := argIndex + 1;
+          var count :- Externs.ParseNat(args[argIndex]);
+          maxDurationStddev := Some(count);
+        }
         case _ => {
           filePaths := filePaths + [arg];
         }
@@ -156,7 +214,9 @@ module Main {
       argIndex := argIndex + 1;
     }
     return Success(Options(maxDurationSeconds := maxDurationSeconds,
-                           maxResourceCount := maxResourceCount, 
+                           maxResourceCount := maxResourceCount,
+                           maxResourceStddev := maxResourceStddev,
+                           maxDurationStddev := maxDurationStddev,
                            filePaths := filePaths));
   }
 }

--- a/src/Statistics.dfy
+++ b/src/Statistics.dfy
@@ -44,7 +44,7 @@ module Statistics {
       stats.min / Externs.DurationTicksPerSecond as real,
       stats.max / Externs.DurationTicksPerSecond as real,
       stats.mean / Externs.DurationTicksPerSecond as real,
-      stats.stddev
+      stats.stddev/ Externs.DurationTicksPerSecond as real
     )
   }
 }

--- a/src/Statistics.dfy
+++ b/src/Statistics.dfy
@@ -44,7 +44,7 @@ module Statistics {
       stats.min / Externs.DurationTicksPerSecond as real,
       stats.max / Externs.DurationTicksPerSecond as real,
       stats.mean / Externs.DurationTicksPerSecond as real,
-      stats.stddev / Externs.DurationTicksPerSecond as real
+      stats.stddev
     )
   }
 }

--- a/src/Statistics.dfy
+++ b/src/Statistics.dfy
@@ -1,0 +1,50 @@
+include "../libraries/src/Collections/Sequences/Seq.dfy"
+include "../libraries/src/Collections/Maps/Maps.dfy"
+
+include "Externs.dfy"
+
+module Statistics {
+  import Externs
+  import Seq
+
+  function method Square(n: real): real { n * n }
+
+  function method Sum(xs: seq<real>): real {
+    Seq.FoldLeft((a, b) => a + b, 0.0, xs)
+  }
+
+  function method Mean(xs: seq<real>): real
+    requires 0 < |xs|
+  {
+    Sum(xs) as real / |xs| as real
+  }
+
+  function method StdDev(xs: seq<real>): real
+    requires 0 < |xs|
+  {
+    var mu := Mean(Seq.Map(x => x as real, xs));
+    var variance := Mean(Seq.Map(x => Square(x as real - mu), xs));
+    Externs.Sqrt(variance)
+  }
+
+  datatype Statistics = Statistics(
+    min: real,
+    max: real,
+    mean: real,
+    stddev: real
+  ) {
+    function method ToString(): string {
+      "min: " + Externs.RealToString(min) + ", max: " + Externs.RealToString(max) +
+      ", mean: " + Externs.RealToString(mean) + ", stddev: " + Externs.RealToString(stddev)
+    }
+  }
+
+  function method StatisticsToSeconds(stats: Statistics): Statistics {
+    Statistics(
+      stats.min / Externs.DurationTicksPerSecond as real,
+      stats.max / Externs.DurationTicksPerSecond as real,
+      stats.mean / Externs.DurationTicksPerSecond as real,
+      stats.stddev / Externs.DurationTicksPerSecond as real
+    )
+  }
+}

--- a/src/TestResult.dfy
+++ b/src/TestResult.dfy
@@ -112,7 +112,7 @@ module TestResult {
     }
   }
 
-  // TODO: there must be an easier way to map a function over a map
+  // TODO: there must be an easier way to fold a function over a map
   method MapResultGroups<T>(groupedResults: map<string, seq<TestResult>>, f: (string, seq<TestResult>) -> T)
     returns (res: seq <(string, T)>)
   {

--- a/src/TestResult.dfy
+++ b/src/TestResult.dfy
@@ -6,6 +6,7 @@ include "../libraries/src/Collections/Maps/Maps.dfy"
 
 include "CSV.dfy"
 include "Externs.dfy"
+include "Statistics.dfy"
 
 module TestResult {
 
@@ -16,6 +17,7 @@ module TestResult {
   import CSV
   import Maps
   import Seq
+  import Statistics
 
   datatype TestResult = TestResult(displayName: string, outcome: string, durationTicks: int64, resourceCount: nat) {
     function method ToString(): string {
@@ -48,5 +50,94 @@ module TestResult {
     var resourceCountStr :- GetCSVRowField(row, RESOURCE_COUNT);
     var resourceCount :- Externs.ParseNat(resourceCountStr);
     Success(TestResult(displayName, outcome, durationTicks, resourceCount))
+  }
+
+  method GroupTestResults(results: seq<TestResult>) returns (groupedResults: map<string, seq<TestResult>>) {
+    groupedResults := map[];
+    for resIndex := 0 to |results| {
+      var res := results[resIndex];
+      var name := res.displayName;
+      if name in groupedResults {
+        groupedResults := groupedResults[name := groupedResults[name] + [res]];
+      } else {
+        groupedResults := groupedResults[name := [res]];
+      }
+    }
+  }
+
+  function method TestResultStatistics(results: seq<TestResult>, f: TestResult -> int): Statistics.Statistics
+  {
+    match 0 < |results| {
+      case true =>
+        var min := Seq.Min(Seq.Map(f, results));
+        var max := Seq.Max(Seq.Map(f, results));
+        var mean := Statistics.Mean(Seq.Map(x => f(x) as real, results));
+        var stddev := Statistics.StdDev(Seq.Map(x => f(x) as real, results));
+        Statistics.Statistics(min as real, max as real, mean, stddev)
+      case false =>
+        Statistics.Statistics(0.0, 0.0, 0.0, 0.0)
+    }
+  }
+
+  function method TestResultDurationStatistics(results: seq<TestResult>): Statistics.Statistics
+  {
+    TestResultStatistics(results, (result: TestResult) => result.durationTicks as int)
+  }
+
+  function method TestResultResourceStatistics(results: seq<TestResult>): Statistics.Statistics
+  {
+    TestResultStatistics(results, (result: TestResult) => result.resourceCount)
+  }
+
+  method PrintTestResultStatistics(displayName: string, results: seq<TestResult>)
+  {
+    var timeStats := TestResultStatistics(results, (r: TestResult) => r.durationTicks as int);
+    var resStats := TestResultStatistics(results, (r: TestResult) => r.resourceCount as int);
+    print displayName, "\n";
+    print "  Time - ", Statistics.StatisticsToSeconds(timeStats).ToString(), "\n";
+    print "  Resource Count - ", resStats.ToString(), "\n";
+  }
+
+  method PrintAllTestResultStatistics(groupedResults: map<string, seq<TestResult>>)
+  {
+    var resultBatches := groupedResults.Items;
+    while resultBatches != {}
+      decreases |resultBatches|
+    {
+      var resultBatch :| resultBatch in resultBatches;
+      resultBatches := resultBatches - {resultBatch};
+      if 0 < |resultBatch.1| { // TODO: could prove that this never happens
+        PrintTestResultStatistics(resultBatch.0, resultBatch.1);
+      }
+    }
+  }
+
+  // TODO: there must be an easier way to map a function over a map
+  method MapResultGroups<T>(groupedResults: map<string, seq<TestResult>>, f: (string, seq<TestResult>) -> T)
+    returns (res: seq <(string, T)>)
+  {
+    var resultBatches := groupedResults.Items;
+    res := [];
+    while resultBatches != {}
+      decreases |resultBatches|
+    {
+      var resultBatch :| resultBatch in resultBatches;
+      resultBatches := resultBatches - {resultBatch};
+      if 0 < |resultBatch.1| { // TODO: could prove that this never happens
+        res := res + [(resultBatch.0, f(resultBatch.0, resultBatch.1))];
+      }
+    }
+  }
+
+  method ResultGroupResourceStddevs(groupedResults: map<string, seq<TestResult>>)
+    returns (res: seq <(string, real)>)
+  {
+    res := MapResultGroups(groupedResults, (name, results) => TestResultResourceStatistics(results).stddev);
+  }
+
+  method ResultGroupDurationStddevs(groupedResults: map<string, seq<TestResult>>)
+    returns (res: seq <(string, real)>)
+  {
+    res := MapResultGroups(groupedResults, (name, results) => TestResultDurationStatistics(results).stddev);
   }
 }


### PR DESCRIPTION
Add two new options for stability analysis

The `--max-resource-stddev` and `--max-duration-stddev` flags to the `summarize-csv-results` command set the maximum value of the standard deviation of the resource count and duration measurements, respectively.

Since each verification execution generates a new CSV file, and the report generator reads all CSV files found, by default, we can just run verification several times to have several measurements for each Dafny proof obligation batch.