### PR TITLE
Improve stability analysis in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Dafny
       uses: dafny-lang/setup-dafny-action@v1
       with:
-        dafny-version: "3.7.0"
+        dafny-version: "3.7.1"
     - name: Verify Dafny code
       run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv"
     - name: Run Tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,6 +41,6 @@ jobs:
         SDFYS=`find src -name "*.dfy"`
         TDFYS=`find test -name "*.dfy"`
         for seed in 1 2 3 4 5; do
-          dafny /compile:0 /verificationLogger:csv /randomSeed:$seed ${SDFYS} ${TDFYS}
+          dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$seed ${SDFYS} ${TDFYS}
         done
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 100000 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Dafny
       uses: dafny-lang/setup-dafny-action@v1
       with:
-        dafny-version: "3.4.2"
+        dafny-version: "3.7.0"
     - name: Verify Dafny code
       run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv"
     - name: Run Tests
@@ -38,9 +38,7 @@ jobs:
       # Runs Dafny directly because it doesn't seem like we can pass
       # multiple arguments to it through MSBuild.
       run: |
-        SDFYS=`find src -name "*.dfy"`
-        TDFYS=`find test -name "*.dfy"`
-        for seed in 1 2 3 4 5; do
-          dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$seed ${SDFYS} ${TDFYS}
-        done
+        SRC_DFYS=`find src -name "*.dfy"`
+        TEST_DFYS=`find test -name "*.dfy"`
+        dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeedIterations:5 ${SRC_DFYS} ${TEST_DFYS}
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 100000 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,6 @@ jobs:
       # multiple arguments to it through MSBuild.
       run: |
         for seed in 1 2 3 4 5; do
-          (cd src && dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$seed Main.dfy)
+          (cd src && dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$seed *.dfy)
         done
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 100000 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,9 @@ jobs:
       # Runs Dafny directly because it doesn't seem like we can pass
       # multiple arguments to it through MSBuild.
       run: |
+        SDFYS=`find src -name "*.dfy"`
+        TDFYS=`find test -name "*.dfy"`
         for seed in 1 2 3 4 5; do
-          (cd src && dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$seed *.dfy)
+          dafny /compile:0 /verificationLogger:csv /randomSeed:$seed ${SDFYS} ${TDFYS}
         done
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 100000 .


### PR DESCRIPTION
* Analyze all Dafny files in `src` and `test`. The previous script mistakenly analyzed only `Main.dfy`.
* Use Dafny 3.7.1 and `/randomSeedIterations`.