### PR TITLE
Add coefficient of variance (CV) limit option

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Self Report
       # Generates a report based on the logged data from verifying itself.
       # This is both a guard against unstable verification and a smoke test of the tool itself.
-      run: dotnet run --project src -- summarize-csv-results --max-resource-count 1500000 .
+      run: dotnet run --project src -- summarize-csv-results --max-resource-count 900000 .
     - name: Stability Analysis
       # Analyzes the stability of verification by running it several
       # more times and calculating statistics
@@ -43,5 +43,5 @@ jobs:
       run: |
         DFYS=`find src test -name "*.dfy"`
         dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeedIterations:5 ${DFYS}
-        dotnet run --project src -- summarize-csv-results --max-resource-stddev 550000 .
-        dotnet run --project src -- summarize-csv-results --max-resource-varcoef 65 .
+        dotnet run --project src -- summarize-csv-results --max-resource-stddev 10000 .
+        dotnet run --project src -- summarize-csv-results --max-resource-varcoef 5 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,4 +44,4 @@ jobs:
         DFYS=`find src test -name "*.dfy"`
         dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeedIterations:5 ${DFYS}
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 10000 .
-        dotnet run --project src -- summarize-csv-results --max-resource-varcoef 5 .
+        dotnet run --project src -- summarize-csv-results --max-resource-cv 5 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,4 +46,4 @@ jobs:
         DFYS=`find src test -name "*.dfy"`
         dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeedIterations:5 ${DFYS}
         dotnet run --project src -- summarize-csv-results --max-resource-stddev 10000 .
-        dotnet run --project src -- summarize-csv-results --max-resource-cv 5 .
+        dotnet run --project src -- summarize-csv-results --max-resource-cv-pct 5 .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,4 +41,8 @@ jobs:
         for seed in 1 2 3 4 5; do
           (cd src && dafny /compile:0 /timeLimit:30 /verificationLogger:csv /randomSeed:$seed Main.dfy)
         done
-        dotnet run --project src -- summarize-csv-results --max-resource-stddev 100000 .
+        # The following limits are actually quite high, but the
+        # libraries repo contributes most of the tricky code. Let's
+        # improve that code and then hopefully lower these limits.
+        dotnet run --project src -- summarize-csv-results --max-resource-stddev 550000 .
+        dotnet run --project src -- summarize-csv-results --max-resource-varcoef 65 .

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are currently two different metrics that you can set a maximum bound on:
     deleting the `TestResults` directory or any of its contents between
     runs.
 
-4. `--max-duration-cv N`
+4. `--max-duration-cv-pct N`
 
     Bounds the _normalized_ standard deviation (a.k.a., coefficient of
     variance, or CV) of multiple measurements of the wall-clock time
@@ -52,12 +52,12 @@ There are currently two different metrics that you can set a maximum bound on:
     to `--max-duration-stddev` but more stable between different runs
     and across different platforms.
 
-6. `--max-resource-cv N`
+6. `--max-resource-cv-pct N`
 
     Bounds the _normalized_ standard deviation (a.k.a. coefficient of
     variance, or CV) of multiple measurements of the solver "resources"
     needed to complete a verification task. This is similar to
-    `--max-duration-varcoef` but more stable between different runs and
+    `--max-duration-cv-pct` but more stable between different runs and
     across different platforms.
 
 5. `--allow-different-outcomes`

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ There are currently two different metrics that you can set a maximum bound on:
     deleting the `TestResults` directory or any of its contents between
     runs.
 
-4. `--max-duration-varcoef N`
+4. `--max-duration-cv N`
 
     Bounds the _normalized_ standard deviation (a.k.a., coefficient of
-    variance) of multiple measurements of the wall-clock time needed to
-    complete a verification task, as an integer percentage. This
-    decouples variance from total execution time.
+    variance, or CV) of multiple measurements of the wall-clock time
+    needed to complete a verification task, as an integer percentage.
+    This decouples variance from total execution time.
 
 5. `--max-resource-stddev N`
 
@@ -52,11 +52,11 @@ There are currently two different metrics that you can set a maximum bound on:
     to `--max-duration-stddev` but more stable between different runs
     and across different platforms.
 
-6. `--max-resource-varcoef N`
+6. `--max-resource-cv N`
 
     Bounds the _normalized_ standard deviation (a.k.a. coefficient of
-    variance) of multiple measurements of the solver "resources" needed
-    to complete a verification task. This is similar to
+    variance, or CV) of multiple measurements of the solver "resources"
+    needed to complete a verification task. This is similar to
     `--max-duration-varcoef` but more stable between different runs and
     across different platforms.
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,27 @@ There are currently two different metrics that you can set a maximum bound on:
     deleting the `TestResults` directory or any of its contents between
     runs.
 
-4. `--max-resource-stddev N`
+4. `--max-duration-varcoef N`
 
-    Bounds the standard deviation of multiple measurements of the
-    solver "resources" needed to complete a verification task. This is
-    similar to `--max-duration-stddev` but more stable between different
-    runs and across different platforms.
+    Bounds the _normalized_ standard deviation (a.k.a., coefficient of
+    variance) of multiple measurements of the wall-clock time needed to
+    complete a verification task, as an integer percentage. This
+    decouples variance from total execution time.
+
+5. `--max-resource-stddev N`
+
+    Bounds the standard deviation of multiple measurements of the solver
+    "resources" needed to complete a verification task. This is similar
+    to `--max-duration-stddev` but more stable between different runs
+    and across different platforms.
+
+6. `--max-resource-varcoef N`
+
+    Bounds the _normalized_ standard deviation (a.k.a. coefficient of
+    variance) of multiple measurements of the solver "resources" needed
+    to complete a verification task. This is similar to
+    `--max-duration-varcoef` but more stable between different runs and
+    across different platforms.
 
 Here is an example of the output of this tool when run against the results of verifying itself. The CSV files
 were created by passing `/verificationLogger:csv` when invoking the `dafny` command-line tool. The maximum resource count

--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -64,7 +64,7 @@ namespace Externs_Compile {
     }
 
     private static Double BigRationalToDouble(BigRational r) {
-      if (r.den == 0) {
+      if (r.num == 0) {
         return 0.0;
       } else {
         return (double)r.num / (double)r.den;

--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -64,7 +64,11 @@ namespace Externs_Compile {
     }
 
     private static Double BigRationalToDouble(BigRational r) {
-      return (double)r.num / (double)r.den;
+      if (r.den == 0) {
+        return 0.0;
+      } else {
+        return (double)r.num / (double)r.den;
+      }
     }
 
     public static icharseq RealToString(BigRational r) {

--- a/src/Main.dfy
+++ b/src/Main.dfy
@@ -142,7 +142,7 @@ module Main {
 
     if options.maxDurationCV.Some? {
       var CVs := ResultGroupStatistics(groupedResults, results => TestResultDurationStatistics(results).CV());
-      passed := PrintExceedingValues("duration CV", CVs, options.maxDurationCV.value);
+      passed := PrintExceedingValues("duration coefficient of variance", CVs, options.maxDurationCV.value);
     }
 
     if options.maxResourceStddev.Some? {
@@ -152,7 +152,7 @@ module Main {
 
     if options.maxResourceCV.Some? {
       var CVs := ResultGroupStatistics(groupedResults, results => TestResultResourceStatistics(results).CV());
-      passed := PrintExceedingValues("resource CV", CVs, options.maxResourceCV.value);
+      passed := PrintExceedingValues("resource coefficient of variance", CVs, options.maxResourceCV.value);
     }
   }
 
@@ -180,9 +180,9 @@ module Main {
       "usage: dafny-reportgenerator summarize-csv-results [--max-resource-count N]\n" +
       "                                                   [--max-duration-seconds N]\n" +
       "                                                   [--max-resource-stddev N]\n" +
-      "                                                   [--max-resource-cv N]\n" +
+      "                                                   [--max-resource-cv-pct N]\n" +
       "                                                   [--max-duration-stddev N]\n" +
-      "                                                   [--max-duration-cv N]\n" +
+      "                                                   [--max-duration-cv-pct N]\n" +
       "                                                   [file_paths ...]\n" +
       "\n" +
       "file_paths                 CSV files produced from Dafny's /verificationLogger:csv feature.\n" +
@@ -192,12 +192,12 @@ module Main {
       "--max-duration-seconds N   Fail if any results have a duration over the given value in seconds.\n" +
       "--max-resource-stddev N    Fail if multiple results exist for each proof obligation and the standard\n" +
       "                           deviation of their resource counts is over the given value.\n" +
-      "--max-resource-cv N        Fail if multiple results exist for each proof obligation and the coefficient\n" +
+      "--max-resource-cv-pct N    Fail if multiple results exist for each proof obligation and the coefficient\n" +
       "                           of variance (stddev / mean) of their resource counts is over the given\n" +
       "                           value (stated as an integer percentage).\n" +
       "--max-duration-stddev N    Fail if multiple results exist for each proof obligation and the standard\n" +
       "                           deviation of their durations is over the given value.\n" +
-      "--max-duration-cv N        Fail if multiple results exist for each proof obligation and the coefficient\n" +
+      "--max-duration-cv-pct N    Fail if multiple results exist for each proof obligation and the coefficient\n" +
       "                           of variance (stddev / mean) of their durations is over the given value (stated\n" +
       "                           as an integer percentage).\n" +
       "";
@@ -249,7 +249,7 @@ module Main {
           argIndex := argIndex + 1;
           maxResourceStddev := Some(count as real);
         }
-        case "--max-resource-cv" => {
+        case "--max-resource-cv-pct" => {
           var pct :- ParseCommandLineNat(args, argIndex);
           argIndex := argIndex + 1;
           maxResourceCV := Some(pct as real / 100.0);
@@ -259,7 +259,7 @@ module Main {
           argIndex := argIndex + 1;
           maxDurationStddev := Some((seconds * Externs.DurationTicksPerSecond) as real);
         }
-        case "--max-duration-cv" => {
+        case "--max-duration-cv-pct" => {
           var pct :- ParseCommandLineNat(args, argIndex);
           argIndex := argIndex + 1;
           maxDurationCV := Some(pct as real / 100.0);

--- a/src/Statistics.dfy
+++ b/src/Statistics.dfy
@@ -36,7 +36,7 @@ module Statistics {
     function method ToString(): string {
       "min: " + Externs.RealToString(min) + ", max: " + Externs.RealToString(max) +
       ", mean: " + Externs.RealToString(mean) + ", stddev: " + Externs.RealToString(stddev) +
-      ", CV: " + Externs.RealToString(CV())
+      ", coefficient of variance: " + Externs.RealToString(CV())
     }
 
     function method CV(): real

--- a/src/Statistics.dfy
+++ b/src/Statistics.dfy
@@ -36,10 +36,10 @@ module Statistics {
     function method ToString(): string {
       "min: " + Externs.RealToString(min) + ", max: " + Externs.RealToString(max) +
       ", mean: " + Externs.RealToString(mean) + ", stddev: " + Externs.RealToString(stddev) +
-      ", coeff. of var.: " + Externs.RealToString(CoefficientOfVariance())
+      ", CV: " + Externs.RealToString(CV())
     }
 
-    function method CoefficientOfVariance(): real
+    function method CV(): real
     {
       if mean == 0.0 then 0.0 else stddev / mean
     }

--- a/src/Statistics.dfy
+++ b/src/Statistics.dfy
@@ -35,7 +35,13 @@ module Statistics {
   ) {
     function method ToString(): string {
       "min: " + Externs.RealToString(min) + ", max: " + Externs.RealToString(max) +
-      ", mean: " + Externs.RealToString(mean) + ", stddev: " + Externs.RealToString(stddev)
+      ", mean: " + Externs.RealToString(mean) + ", stddev: " + Externs.RealToString(stddev) +
+      ", coeff. of var.: " + Externs.RealToString(CoefficientOfVariance())
+    }
+
+    function method CoefficientOfVariance(): real
+    {
+      if mean == 0.0 then 0.0 else stddev / mean
     }
   }
 

--- a/src/TestResult.dfy
+++ b/src/TestResult.dfy
@@ -118,15 +118,9 @@ module TestResult {
     res := StandardLibrary.MapToSeq(map k | k in groupedResults :: f(k, groupedResults[k]));
   }
 
-  method ResultGroupResourceStddevs(groupedResults: map<string, seq<TestResult>>)
+  method ResultGroupStatistics(groupedResults: map<string, seq<TestResult>>, f: seq<TestResult> -> real)
     returns (res: seq <(string, real)>)
   {
-    res := MapResultGroups(groupedResults, (name, results) => TestResultResourceStatistics(results).stddev);
-  }
-
-  method ResultGroupDurationStddevs(groupedResults: map<string, seq<TestResult>>)
-    returns (res: seq <(string, real)>)
-  {
-    res := MapResultGroups(groupedResults, (name, results) => TestResultDurationStatistics(results).stddev);
+    res := MapResultGroups(groupedResults, (name, results) => f(results));
   }
 }


### PR DESCRIPTION
This PR adds support for normalized standard deviation (also known as coefficient of variance, or CV) analysis. This is a more standardized and likely user-friendly way to look at how much values vary. Settling on a standard limit of, say, 20% might be reasonable (or maybe less?).

This PR adds the new analysis to CI (with a limit of 5%). It also includes some refactoring to improve stability of its own code. It also fixes a bug in `double` to `BigRational` (`real`) conversion.