### PR TITLE
Fail if a single procedure has different outcomes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,10 @@ jobs:
     - name: Verify Dafny code
       run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv"
     - name: Run Tests
-      run: dotnet test --verbosity normal
+      run: |
+        dotnet test --verbosity normal
+        # Ensure failure on a concrete CSV with inconsistent outcomes
+        ! dotnet run --project src -- summarize-csv-results test/diff-outcomes.csv
     - name: Self Report
       # Generates a report based on the logged data from verifying itself.
       # This is both a guard against unstable verification and a smoke test of the tool itself.

--- a/src/Main.dfy
+++ b/src/Main.dfy
@@ -123,7 +123,7 @@ module Main {
     if |inconsistentResults| > 0 {
       print "The following results have inconsistent outcomes:\n";
       for i := 0 to |inconsistentResults| {
-        print "  ", inconsistentResults[i].1, "\n";
+        print "  ", inconsistentResults[i].0, "\n";
       }
       passed := false;
     }

--- a/src/Main.dfy
+++ b/src/Main.dfy
@@ -68,7 +68,9 @@ module Main {
 
     // Group the results by name, for aggregate statistics
     var groupedResults := GroupTestResults(allResultsSorted);
-    
+    var groupedResultConsistency := ResultGroupConsistency(groupedResults);
+    var inconsistentResults := Filter((r: (string, bool)) => !r.1, groupedResultConsistency);
+
     if options.maxResourceStddev.Some? || options.maxDurationStddev.Some? {
       print "All results (statistics):\n\n";
       PrintAllTestResultStatistics(groupedResults);
@@ -116,6 +118,14 @@ module Main {
     if options.maxResourceStddev.Some? {
       var stddevs := ResultGroupResourceStddevs(groupedResults);
       passed := PrintExceedingStddevs("resource count", stddevs, options.maxResourceStddev.value);
+    }
+
+    if |inconsistentResults| > 0 {
+      print "The following results have inconsistent outcomes:\n";
+      for i := 0 to |inconsistentResults| {
+        print "  ", inconsistentResults[i].1, "\n";
+      }
+      passed := false;
     }
 
     :- Need(passed, "\nErrors occurred: see above for details.\n");

--- a/src/TestResult.dfy
+++ b/src/TestResult.dfy
@@ -67,6 +67,10 @@ module TestResult {
     }
   }
 
+  predicate method ConsistentOutcomes(results: seq<TestResult>) {
+    |Seq.ToSet(Seq.Map((result : TestResult) => result.outcome, results))| == 1
+  }
+
   function method TestResultStatistics(results: seq<TestResult>, f: TestResult -> real): Statistics.Statistics
   {
     if 0 < |results| then
@@ -91,11 +95,12 @@ module TestResult {
 
   method PrintTestResultStatistics(displayName: string, results: seq<TestResult>)
   {
-    var timeStats := TestResultStatistics(results, (r: TestResult) => r.durationTicks as real);
-    var resStats := TestResultStatistics(results, (r: TestResult) => r.resourceCount as real);
+    var timeStats := TestResultDurationStatistics(results);
+    var resStats := TestResultResourceStatistics(results);
     print displayName, "\n";
     print "  Time (seconds) - ", Statistics.StatisticsToSeconds(timeStats).ToString(), "\n";
     print "  Resource count - ", resStats.ToString(), "\n";
+    print "  Consistent outcomes - ", ConsistentOutcomes(results), "\n";
   }
 
   method PrintAllTestResultStatistics(groupedResults: map<string, seq<TestResult>>)
@@ -128,5 +133,11 @@ module TestResult {
     returns (res: seq <(string, real)>)
   {
     res := MapResultGroups(groupedResults, (name, results) => TestResultDurationStatistics(results).stddev);
+  }
+
+  method ResultGroupConsistency(groupedResults: map<string, seq<TestResult>>)
+    returns (res: seq <(string, bool)>)
+  {
+    res := MapResultGroups(groupedResults, (name, results) => ConsistentOutcomes(results));
   }
 }

--- a/src/TestResult.dfy
+++ b/src/TestResult.dfy
@@ -68,7 +68,7 @@ module TestResult {
   }
 
   predicate method ConsistentOutcomes(results: seq<TestResult>) {
-    |Seq.ToSet(Seq.Map((result : TestResult) => result.outcome, results))| == 1
+    |set result <- results :: result.outcome| == 1
   }
 
   function method TestResultStatistics(results: seq<TestResult>, f: TestResult -> real): Statistics.Statistics

--- a/test/diff-outcomes.csv
+++ b/test/diff-outcomes.csv
@@ -1,0 +1,5 @@
+TestResult.DisplayName,TestResult.Outcome,TestResult.Duration,TestResult.ResourceCount
+Proc1,Passed,00:00:00.9390000,1907774
+Proc1,Failed,00:00:00.9390000,1907774
+Proc2,Passed,00:00:00.9390000,1907774
+Proc2,Passed,00:00:00.9390000,1907774


### PR DESCRIPTION
Perhaps the most fundamental definition of verification instability is that the outcome of verification differs between verification attempts. The CSV input consumed by `dafny-reportgenerator` includes an `Outcome` field, and this PR now causes the `summarize-csv-results` command to fail if the number of distinct outcome types for a given procedure is greater than 1. Given that this is always an indication of instability, this check is unconditional.