### PR TITLE
Add `--allow-different-outcomes` flag

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,8 @@ jobs:
         dotnet test --verbosity normal
         # Ensure failure on a concrete CSV with inconsistent outcomes
         ! dotnet run --project src -- summarize-csv-results test/diff-outcomes.csv
+        # Ensure success on a concrete CSV with inconsistent outcomes if asked for
+        dotnet run --project src -- summarize-csv-results --allow-different-outcomes test/diff-outcomes.csv
     - name: Self Report
       # Generates a report based on the logged data from verifying itself.
       # This is both a guard against unstable verification and a smoke test of the tool itself.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ There are currently two different metrics that you can set a maximum bound on:
     similar to `--max-duration-stddev` but more stable between different
     runs and across different platforms.
 
+5. `--allow-different-outcomes`
+
+    Don't fail if a given verification task has more than one type of
+    outcome (e.g., success and timeout). Normally, this is considered an
+    error, but during the process of making a project more stable it can
+    sometimes be useful to allow.
+
 Here is an example of the output of this tool when run against the results of verifying itself. The CSV files
 were created by passing `/verificationLogger:csv` when invoking the `dafny` command-line tool. The maximum resource count
 is set unrealistically low here, just to demonstrate the behavior when violated.

--- a/src/Main.dfy
+++ b/src/Main.dfy
@@ -122,7 +122,7 @@ module Main {
     }
 
     if |inconsistentResults| > 0 && !options.allowDifferentOutcomes {
-      print "\nThe following results have inconsistent outcomes:\n";
+      print "\nThe following results have inconsistent outcomes:\n\n";
       for i := 0 to |inconsistentResults| {
         print "  ", inconsistentResults[i].0, "\n";
       }

--- a/src/Main.dfy
+++ b/src/Main.dfy
@@ -36,6 +36,7 @@ module Main {
                              maxResourceCount: Option<nat> := None,
                              maxDurationStddev: Option<real> := None,
                              maxResourceStddev: Option<real> := None,
+                             allowDifferentOutcomes: bool := false,
                              filePaths: seq<string> := [])
 
   // TODO: It would be nice to return an `Outcome<string>` instead, but the current
@@ -120,8 +121,8 @@ module Main {
       passed := PrintExceedingStddevs("resource count", stddevs, options.maxResourceStddev.value);
     }
 
-    if |inconsistentResults| > 0 {
-      print "The following results have inconsistent outcomes:\n";
+    if |inconsistentResults| > 0 && !options.allowDifferentOutcomes {
+      print "\nThe following results have inconsistent outcomes:\n";
       for i := 0 to |inconsistentResults| {
         print "  ", inconsistentResults[i].0, "\n";
       }
@@ -186,6 +187,7 @@ module Main {
     var maxDurationSeconds: Option<nat> := None;
     var maxResourceStddev: Option<real> := None;
     var maxDurationStddev: Option<real> := None;
+    var allowDifferentOutcomes: bool := false;
     var filePaths: seq<string> := [];
     var argIndex := 2;
     while argIndex < |args| {
@@ -215,6 +217,9 @@ module Main {
           var seconds :- Externs.ParseNat(args[argIndex]);
           maxDurationStddev := Some((seconds * Externs.DurationTicksPerSecond) as real);
         }
+        case "--allow-different-outcomes" => {
+          allowDifferentOutcomes := true;
+        }
         case _ => {
           filePaths := filePaths + [arg];
         }
@@ -225,6 +230,7 @@ module Main {
                            maxResourceCount := maxResourceCount,
                            maxResourceStddev := maxResourceStddev,
                            maxDurationStddev := maxDurationStddev,
+                           allowDifferentOutcomes := allowDifferentOutcomes,
                            filePaths := filePaths));
   }
 }


### PR DESCRIPTION
This allows different outcomes for a single verification task, to allow for smoother migration from an unstable project to a stable project.

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).