### PR TITLE
Fix terminology: CV = coefficient of variation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ There are currently two different metrics that you can set a maximum bound on:
 4. `--max-duration-cv-pct N`
 
     Bounds the _normalized_ standard deviation (a.k.a., coefficient of
-    variance, or CV) of multiple measurements of the wall-clock time
+    variation, or CV) of multiple measurements of the wall-clock time
     needed to complete a verification task, as an integer percentage.
-    This decouples variance from total execution time.
+    This decouples variation from total execution time.
 
 5. `--max-resource-stddev N`
 
@@ -55,7 +55,7 @@ There are currently two different metrics that you can set a maximum bound on:
 6. `--max-resource-cv-pct N`
 
     Bounds the _normalized_ standard deviation (a.k.a. coefficient of
-    variance, or CV) of multiple measurements of the solver "resources"
+    variation, or CV) of multiple measurements of the solver "resources"
     needed to complete a verification task. This is similar to
     `--max-duration-cv-pct` but more stable between different runs and
     across different platforms.

--- a/src/Main.dfy
+++ b/src/Main.dfy
@@ -142,7 +142,7 @@ module Main {
 
     if options.maxDurationCV.Some? {
       var CVs := ResultGroupStatistics(groupedResults, results => TestResultDurationStatistics(results).CV());
-      passed := PrintExceedingValues("duration coefficient of variance", CVs, options.maxDurationCV.value);
+      passed := PrintExceedingValues("duration coefficient of variation", CVs, options.maxDurationCV.value);
     }
 
     if options.maxResourceStddev.Some? {
@@ -152,7 +152,7 @@ module Main {
 
     if options.maxResourceCV.Some? {
       var CVs := ResultGroupStatistics(groupedResults, results => TestResultResourceStatistics(results).CV());
-      passed := PrintExceedingValues("resource coefficient of variance", CVs, options.maxResourceCV.value);
+      passed := PrintExceedingValues("resource coefficient of variation", CVs, options.maxResourceCV.value);
     }
   }
 
@@ -193,12 +193,12 @@ module Main {
       "--max-resource-stddev N    Fail if multiple results exist for each proof obligation and the standard\n" +
       "                           deviation of their resource counts is over the given value.\n" +
       "--max-resource-cv-pct N    Fail if multiple results exist for each proof obligation and the coefficient\n" +
-      "                           of variance (stddev / mean) of their resource counts is over the given\n" +
+      "                           of variation (stddev / mean) of their resource counts is over the given\n" +
       "                           value (stated as an integer percentage).\n" +
       "--max-duration-stddev N    Fail if multiple results exist for each proof obligation and the standard\n" +
       "                           deviation of their durations is over the given value.\n" +
       "--max-duration-cv-pct N    Fail if multiple results exist for each proof obligation and the coefficient\n" +
-      "                           of variance (stddev / mean) of their durations is over the given value (stated\n" +
+      "                           of variation (stddev / mean) of their durations is over the given value (stated\n" +
       "                           as an integer percentage).\n" +
       "";
 

--- a/src/Statistics.dfy
+++ b/src/Statistics.dfy
@@ -36,7 +36,7 @@ module Statistics {
     function method ToString(): string {
       "min: " + Externs.RealToString(min) + ", max: " + Externs.RealToString(max) +
       ", mean: " + Externs.RealToString(mean) + ", stddev: " + Externs.RealToString(stddev) +
-      ", coefficient of variance: " + Externs.RealToString(CV())
+      ", coefficient of variation: " + Externs.RealToString(CV())
     }
 
     function method CV(): real


### PR DESCRIPTION
It's not "coefficient of variance". Fortunately, this just changes messages and help text, not command-line options.