### PR TITLE
chore: Setting up nightly build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,10 +6,23 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+    inputs:
+      nightly:
+        description: 'Run the nightly build'
+        required: false
+        type: boolean
+  schedule:
+    # Nightly build against Dafny's nightly prereleases,
+    # for early warning of verification issues or regressions.
+    # Timing chosen to be adequately after Dafny's own nightly build,
+    # but this might need to be tweaked:
+    # https://github.com/dafny-lang/dafny/blob/master/.github/workflows/deep-tests.yml#L16
+    - cron: "30 8 * * *"
 
 jobs:
   build:
-
+    # Don't run the nightly build on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'dafny-lang'
     runs-on: ubuntu-latest
 
     steps:
@@ -20,10 +33,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
-    - name: Set up Dafny
-      uses: dafny-lang/setup-dafny-action@v1
+    - name: Setup Dafny
+      uses: dafny-lang/setup-dafny-action@v1.6.0
       with:
-        dafny-version: "3.7.1"
+        dafny-version: ${{ (github.event_name == schedule || inputs.nightly) && 'nightly-latest' || '3.7.1' }}
     - name: Verify Dafny code
       run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv"
     - name: Run Tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Dafny
       uses: dafny-lang/setup-dafny-action@v1.6.0
       with:
-        dafny-version: ${{ (github.event_name == schedule || inputs.nightly) && 'nightly-latest' || '3.7.1' }}
+        dafny-version: ${{ (github.event_name == 'schedule' || inputs.nightly) && 'nightly-latest' || '3.7.1' }}
     - name: Verify Dafny code
       run: dotnet build -t:VerifyDafny -p:VerifyDafnyJobs=2 -p:TestVerifyOverride="verificationLogger:csv"
     - name: Run Tests


### PR DESCRIPTION
The nightly build runs the same CI as on PRs, but uses the latest nightly Dafny prerelease in place of the configured target version.

This is a recommended best practice for early warning on verification variation on upcoming releases, and to catch potential regressions before they are released.

Forced this into master on my fork so I could manually run the nightly version: https://github.com/robin-aws/dafny-reportgenerator/actions/runs/4208167715/jobs/7303873778 It does the job nicely since something breaks! It's reasonable to fix that later as the nightly build is intended to be only an early warning and not to block development immediately.